### PR TITLE
fix(collect_stats): handle GitHub API rate-limit errors and missing-platform assets

### DIFF
--- a/collect_stats.py
+++ b/collect_stats.py
@@ -10,6 +10,7 @@ def downloads(verbose=False):
     r = requests.get(
         "https://api.github.com/repos/ActivityWatch/activitywatch/releases?per_page=100"
     )
+    r.raise_for_status()
     d = r.json()
 
     downloads = 0
@@ -17,18 +18,24 @@ def downloads(verbose=False):
         if verbose:
             print("Release: ", release["tag_name"])
         for asset in release["assets"]:
-            platform = re.findall("(macos|darwin|linux|windows)", asset["name"])[0]
+            platform_match = re.findall("(macos|darwin|linux|windows)", asset["name"])
             count = asset["download_count"]
             if verbose:
+                platform = platform_match[0] if platform_match else "unknown"
                 print(" - {}: {}".format(platform, count))
 
-            downloads += asset["download_count"]
+            downloads += count
     return downloads
 
 
 def stars():
     r = requests.get("https://api.github.com/repos/ActivityWatch/activitywatch")
+    r.raise_for_status()
     d = r.json()
+    if "stargazers_count" not in d:
+        raise RuntimeError(
+            f"GitHub API did not return stargazers_count: {d.get('message', 'unknown response')}"
+        )
     return d["stargazers_count"]
 
 


### PR DESCRIPTION
## Problem

CI was failing intermittently with `KeyError: 'stargazers_count'` in `stars()`:

```
File "collect_stats.py", line 32, in stars
    return d["stargazers_count"]
KeyError: 'stargazers_count'
```

This happens when GitHub rate-limits the request — the API returns a `{"message": "API rate limit exceeded..."}` response instead of the repo object. Since `stars()` is called before `downloads()`, a rate-limit failure prevents download stats from being collected and committed at all.

Confirmed failures in March 2026: 2026-03-04, 2026-03-08, 2026-03-14, 2026-03-20.

## Fix

- **`stars()`**: add `raise_for_status()` for HTTP errors + explicit check for the expected key with a descriptive error message
- **`downloads()`**: add `raise_for_status()` + guard the platform regex so assets without a recognized platform name in their filename don't crash the loop (their download count is still counted)

## Test

Both functions now raise clear exceptions with useful messages on API errors instead of cryptic `KeyError`/`IndexError`.