### PR TITLE
fix(ci): authenticate collect_stats GitHub API requests

### DIFF
--- a/.github/workflows/collect-stats.yml
+++ b/.github/workflows/collect-stats.yml
@@ -30,6 +30,8 @@ jobs:
     - name: Install dependencies
       run: poetry install
     - name: Collect and append stats
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         poetry run python3 collect_stats.py --csv >> data/stats.csv
         # This has started causing "rate-limit exceeded", breaking CI.

--- a/collect_stats.py
+++ b/collect_stats.py
@@ -1,17 +1,25 @@
 import re
 from pprint import pprint
 import sys
+import os
 from datetime import datetime, timezone, date
 
 import requests
 
 
+def github_get(path: str):
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    response = requests.get(f"https://api.github.com{path}", headers=headers, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
 def downloads(verbose=False):
-    r = requests.get(
-        "https://api.github.com/repos/ActivityWatch/activitywatch/releases?per_page=100"
-    )
-    r.raise_for_status()
-    d = r.json()
+    d = github_get("/repos/ActivityWatch/activitywatch/releases?per_page=100")
 
     downloads = 0
     for release in d:
@@ -29,9 +37,7 @@ def downloads(verbose=False):
 
 
 def stars():
-    r = requests.get("https://api.github.com/repos/ActivityWatch/activitywatch")
-    r.raise_for_status()
-    d = r.json()
+    d = github_get("/repos/ActivityWatch/activitywatch")
     if "stargazers_count" not in d:
         raise RuntimeError(
             f"GitHub API did not return stargazers_count: {d.get('message', 'unknown response')}"
@@ -41,10 +47,7 @@ def stars():
 
 def clones():
     # TODO: Needs push access to the repository
-    r = requests.get(
-        "https://api.github.com/repos/ActivityWatch/activitywatch/traffic/clones?per=day"
-    )
-    d = r.json()
+    d = github_get("/repos/ActivityWatch/activitywatch/traffic/clones?per=day")
     pprint(d)
 
 
@@ -64,21 +67,14 @@ def releases():
     Fetch all releases and their dates from the GitHub API.
     NOTE: Needs to use the commit date, not the release date, for some releases that had to be re-released (like v0.10.0).
     """
-    r = requests.get(
-        "https://api.github.com/repos/ActivityWatch/activitywatch/releases?per_page=100"
-    )
-    r.raise_for_status()
-    d = r.json()
+    d = github_get("/repos/ActivityWatch/activitywatch/releases?per_page=100")
 
     releases: dict[str, date] = {}
     for release in d:
         # We need to fetch the commit of the tag and use its date
-        r = requests.get(
-            "https://api.github.com/repos/ActivityWatch/activitywatch/commits/"
-            + release["tag_name"]
+        commit = github_get(
+            "/repos/ActivityWatch/activitywatch/commits/" + release["tag_name"]
         )
-        r.raise_for_status()
-        commit = r.json()
         releases[release["tag_name"]] = (
             datetime.strptime(
                 commit["commit"]["committer"]["date"],


### PR DESCRIPTION
## Problem

PR #8 improved the error message, but the merged workflow still fails on `master` when the collector hits GitHub's anonymous rate limit.

Latest failure: run `24991803400` on 2026-04-27 failed with:

```txt
requests.exceptions.HTTPError: 403 Client Error: rate limit exceeded for url: https://api.github.com/repos/ActivityWatch/activitywatch
```

The collector is still making anonymous REST calls from a shared GitHub Actions runner IP, so the scheduled job can keep tripping the 60/hour bucket.

## Fix

- add a small `github_get()` helper in `collect_stats.py`
- send `Authorization: Bearer $GITHUB_TOKEN` when the workflow provides one
- pass `${{ secrets.GITHUB_TOKEN }}` into the `Collect and append stats` step
- reuse the helper for the release, stars, and commit lookups

## Test

- `python3 -m py_compile collect_stats.py`
- local mock-based check that `github_get()` adds the auth header when `GITHUB_TOKEN` is set and omits it otherwise
