### PR TITLE
fix: restore poetry package-mode=false (unbreak activitywatch.github.io build)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,10 @@ dependencies = [
     "matplotlib",
     "click",
 ]
+
+# This project is a set of scripts, not an installable package. package-mode is
+# a poetry-specific setting; it's kept so downstream consumers that run
+# `poetry install` (e.g. the activitywatch.github.io site build) don't fail
+# trying to install a non-existent "aw-stats" package. uv reads [project] above.
+[tool.poetry]
+package-mode = false


### PR DESCRIPTION
## Problem

The [activitywatch.github.io site build](https://github.com/ActivityWatch/activitywatch.github.io/actions/runs/29166657151/job/86580796234) broke after the uv switch (#10):

```
cd stats && poetry install
Error: The current project could not be installed: No file/folder found for package aw-stats
make: *** [Makefile:63: img/stats] Error 1
```

The site's `img/stats` target clones this repo and runs `poetry install` + `poetry run python analyze_stats.py …` to render the download/Chrome/Firefox/Android charts. #10 converted `pyproject.toml` to pure PEP 621 and dropped `package-mode = false`, so poetry 2.x now tries to install `aw-stats` as a package and fails.

## Fix

Re-add `[tool.poetry] package-mode = false`. The file stays PEP 621 for uv (`[project]`), and poetry reads that for deps while skipping the non-existent root package — so it works with both tools.

## Verification
- `poetry check` → "All set!"; `poetry install` succeeds (no root-package error).
- `uv sync` still works.
- All four `analyze_stats.py --column … --save` commands the site runs render valid PNGs under the new pandas 3.0 / matplotlib 3.11.

Didn't commit a `poetry.lock` — `uv.lock` stays canonical; poetry resolves deps from `[project]`.