### PR TITLE
fix: smooth per-day rate chart + honest label (unbreak jagged downloads.png)

### DIFF
--- a/analyze_stats.py
+++ b/analyze_stats.py
@@ -158,10 +158,13 @@ def main(
         df_w = df.diff()
         df_w = df_w[df_w > 0]  # Filter out the crazy outlier
         df_w = df_w.resample("1D").mean()
+        # Always smooth out the day-to-day noise; per-week is the same daily
+        # rate scaled up by 7, not a different (jagged) series.
+        df_w = df_w.rolling("7D").mean()
         if per_week:
-            df_w = df_w.rolling("7D").mean() * 7
+            df_w = df_w * 7
         df_w.plot(ax=ax)
-        ax.set_title(f"Per {'week' if per_week else 'day'} (rolling)")
+        ax.set_title(f"Per {'week' if per_week else 'day'} (7d rolling mean)")
         ax.set_ylim(0)
         ax.grid(True, which="major", **gridargs)
         ax.legend()


### PR DESCRIPTION
The site's downloads.png is rendered with `analyze_stats.py --column downloads --per-day`. PR #10 gated the 7d rolling smoothing behind `--per-week`, so `--per-day` began plotting the raw `diff()` (jagged) and still mislabeled it "Per day (rolling)".

This always applies the 7d rolling mean (`--per-week` = same rate ×7) and labels it "(7d rolling mean)". Measured ~5x reduction in day-to-day noise; both `--per-day` and `--per-week` render cleanly.

Note: this makes the site's per-day chart smooth again. If you'd rather the chart show weekly magnitude (as it did before #10), that's a one-line switch to `--per-week` in the activitywatch.github.io Makefile — see my follow-up question.