### PR TITLE
fix(ci): hold installs update pending metric decision

### DIFF
--- a/.github/workflows/collect-play.yml
+++ b/.github/workflows/collect-play.yml
@@ -31,17 +31,17 @@ jobs:
         printf '%s' "$PLAY_SA_JSON" > "$GOOGLE_APPLICATION_CREDENTIALS"
         uv run vitals.py crash-rate --days 30 --update data/android-crash-rate.csv
         uv run vitals.py anr-rate   --days 30 --update data/android-anr-rate.csv
-        # Non-fatal: skip installs if the bucket ACL isn't in place yet.
-        if [ -n "$PLAY_BUCKET" ]; then
-          uv run android_installs.py --bucket "$PLAY_BUCKET" update || echo "installs update skipped"
-        fi
+        # installs/installed.csv is intentionally disabled pending the metric
+        # decision (Installed audience vs Active Device Installs) — see #17.
+        # The SA can now read the bucket, so re-enable once decided:
+        #   uv run android_installs.py --bucket "$PLAY_BUCKET" update
         rm -f "$GOOGLE_APPLICATION_CREDENTIALS"
     - name: Commit
       if: env.HAS_SA == 'true'
       run: |
         git config --local user.email "noreply@github.com"
         git config --local user.name "GitHub Action"
-        git add data/android-crash-rate.csv data/android-anr-rate.csv data/android/installed.csv
+        git add data/android-crash-rate.csv data/android-anr-rate.csv
         git diff --cached --quiet || git commit -m "chore: update Play Console stats"
     - name: Push changes
       if: env.HAS_SA == 'true'


### PR DESCRIPTION
Now that the SA's bucket access propagated, the daily `collect-play.yml` would overwrite `installed.csv` (manual Installed-audience, user-based) with Active Device Installs (device-based, ~10% higher) before the metric decision (#17) is made. Disable just that step; vitals keep flowing. Re-enable once decided.