### PR TITLE
fix(android_installs): restrict zero filtering to trailing tail only

### DIFF
--- a/android_installs.py
+++ b/android_installs.py
@@ -110,10 +110,14 @@ def parse_report(raw: bytes, metric_column: str) -> dict[str, str]:
     for row in csv.DictReader(io.StringIO(text)):
         date = (row.get("Date") or "").strip()
         value = (row.get(metric_column) or "").strip().replace(",", "")
-        # Skip "0": Play leaves not-yet-finalized recent days as 0, which would
-        # otherwise be a spurious dip in the install base.
-        if date and value and value != "0":
+        if date and value:
             out[date] = value
+    # Drop only the trailing-zero suffix: Play leaves not-yet-finalized recent
+    # days as "0", which would otherwise appear as spurious dips. Internal zeros
+    # (rare but valid — e.g. a reporting gap mid-series) are kept as-is.
+    dates = sorted(out)
+    while dates and out[dates[-1]] == "0":
+        del out[dates.pop()]
     return out
 
 


### PR DESCRIPTION
## Summary

Fixes the bug identified by the Codex bot in PR #19 review comment [discussion_r3566750142](https://github.com/ActivityWatch/stats/pull/19#discussion_r3566750142).

**Problem**: `parse_report()` filtered out *any* row with value `"0"`, but the intent was to suppress only Play Store's unfinalized trailing days (which report as 0). An internal zero (e.g. 2026-07-06 in the rebuild) is silently dropped, creating a gap in the install series that `analyze_stats._load_data()` then interpolates over.

**Fix**: Collect all rows, then strip only the trailing-zero suffix in a second pass. This preserves valid internal zeros while still suppressing Play's unfinalized-tail noise.

```python
# Before: drops ALL zeros
if date and value and value != "0":
    out[date] = value

# After: keep all, trim trailing zeros only
if date and value:
    out[date] = value
dates = sorted(out)
while dates and out[dates[-1]] == "0":
    del out[dates.pop()]
```